### PR TITLE
Remove unused vector plan node subclasses

### DIFF
--- a/docs/design_docs/segcore/visitor.md
+++ b/docs/design_docs/segcore/visitor.md
@@ -2,8 +2,7 @@
 Visitor Pattern is used in segcore for parse and execute Execution Plan.
 
 1. Inside `${internal/core}/src/query/PlanNode.h`, contains physical plan for vector search:
-    1. `FloatVectorANNS` FloatVector search execution node
-    2. `BinaryVectorANNS` BinaryVector search execution node
+    1. `VectorPlanNode` vector search execution node
 2. `${internal/core}/src/query/Expr.h` contains physical plan for scalar expression:
     1. `TermExpr` support operation like `col in [1, 2, 3]`
     2. `RangeExpr` support constant compare with data column like `a >= 5` `1 < b < 2`

--- a/internal/core/src/exec/expression/ExprTest.cpp
+++ b/internal/core/src/exec/expression/ExprTest.cpp
@@ -216,7 +216,7 @@ TEST_P(ExprTest, InvalidRange) {
 }
 
 TEST_P(ExprTest, ShowExecutor) {
-    auto node = std::make_unique<FloatVectorANNS>();
+    auto node = std::make_unique<VectorPlanNode>();
     auto schema = std::make_shared<Schema>();
     auto field_id =
         schema->AddDebugField("fakevec", data_type, 16, metric_type);

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -111,7 +111,6 @@ ExecPlanNodeVisitor::ExecuteTask(
     return bitset_holder;
 }
 
-template <typename VectorType>
 void
 ExecPlanNodeVisitor::VectorVisitorImpl(VectorPlanNode& node) {
     assert(!search_result_opt_.has_value());
@@ -216,38 +215,8 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
 }
 
 void
-ExecPlanNodeVisitor::visit(FloatVectorANNS& node) {
-    VectorVisitorImpl<FloatVector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(BinaryVectorANNS& node) {
-    VectorVisitorImpl<BinaryVector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(Float16VectorANNS& node) {
-    VectorVisitorImpl<Float16Vector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(BFloat16VectorANNS& node) {
-    VectorVisitorImpl<BFloat16Vector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(SparseFloatVectorANNS& node) {
-    VectorVisitorImpl<SparseFloatVector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(Int8VectorANNS& node) {
-    VectorVisitorImpl<Int8Vector>(node);
-}
-
-void
-ExecPlanNodeVisitor::visit(EmbListFloatVectorANNS& node) {
-    VectorVisitorImpl<EmbListFloatVector>(node);
+ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
+    VectorVisitorImpl(node);
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -23,28 +23,12 @@ namespace milvus::query {
 class ExecPlanNodeVisitor : public PlanNodeVisitor {
  public:
     void
-    visit(FloatVectorANNS& node) override;
-
-    void
-    visit(BinaryVectorANNS& node) override;
-
-    void
-    visit(Float16VectorANNS& node) override;
-
-    void
-    visit(BFloat16VectorANNS& node) override;
-
-    void
-    visit(SparseFloatVectorANNS& node) override;
-
-    void
-    visit(Int8VectorANNS& node) override;
+    visit(VectorPlanNode& node) override;
 
     void
     visit(RetrievePlanNode& node) override;
 
-    void
-    visit(EmbListFloatVectorANNS& node) override;
+    // no extra visit for vector types
 
  public:
     ExecPlanNodeVisitor(const segcore::SegmentInterface& segment,
@@ -108,7 +92,6 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
                 std::shared_ptr<milvus::exec::QueryContext> query_context);
 
  private:
-    template <typename VectorType>
     void
     VectorVisitorImpl(VectorPlanNode& node);
 

--- a/internal/core/src/query/PlanNode.cpp
+++ b/internal/core/src/query/PlanNode.cpp
@@ -16,32 +16,7 @@
 
 namespace milvus::query {
 void
-FloatVectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
-
-void
-BinaryVectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
-
-void
-Float16VectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
-
-void
-BFloat16VectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
-
-void
-SparseFloatVectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
-
-void
-Int8VectorANNS::accept(PlanNodeVisitor& visitor) {
+VectorPlanNode::accept(PlanNodeVisitor& visitor) {
     visitor.visit(*this);
 }
 
@@ -50,9 +25,6 @@ RetrievePlanNode::accept(PlanNodeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void
-EmbListFloatVectorANNS::accept(PlanNodeVisitor& visitor) {
-    visitor.visit(*this);
-}
+// no other vector plan node types
 
 }  // namespace milvus::query

--- a/internal/core/src/query/PlanNode.h
+++ b/internal/core/src/query/PlanNode.h
@@ -43,51 +43,13 @@ struct PlanNode {
 using PlanNodePtr = std::unique_ptr<PlanNode>;
 
 struct VectorPlanNode : PlanNode {
+ public:
+    void
+    accept(PlanNodeVisitor&) override;
+
     SearchInfo search_info_;
     std::string placeholder_tag_;
     std::shared_ptr<milvus::plan::PlanNode> plannodes_;
-};
-
-struct FloatVectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct BinaryVectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct Float16VectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct BFloat16VectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct SparseFloatVectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct Int8VectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
-};
-
-struct EmbListFloatVectorANNS : VectorPlanNode {
- public:
-    void
-    accept(PlanNodeVisitor&) override;
 };
 
 struct RetrievePlanNode : PlanNode {

--- a/internal/core/src/query/PlanNodeVisitor.h
+++ b/internal/core/src/query/PlanNodeVisitor.h
@@ -20,27 +20,9 @@ class PlanNodeVisitor {
 
  public:
     virtual void
-    visit(FloatVectorANNS&) = 0;
-
-    virtual void
-    visit(BinaryVectorANNS&) = 0;
-
-    virtual void
-    visit(Float16VectorANNS&) = 0;
-
-    virtual void
-    visit(BFloat16VectorANNS&) = 0;
-
-    virtual void
-    visit(SparseFloatVectorANNS&) = 0;
-
-    virtual void
-    visit(Int8VectorANNS&) = 0;
+    visit(VectorPlanNode&) = 0;
 
     virtual void
     visit(RetrievePlanNode&) = 0;
-
-    virtual void
-    visit(EmbListFloatVectorANNS&) = 0;
 };
 }  // namespace milvus::query

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -130,29 +130,7 @@ ProtoParser::PlanNodeFromProto(const planpb::PlanNode& plan_node_proto) {
         return search_info;
     };
 
-    auto plan_node = [&]() -> std::unique_ptr<VectorPlanNode> {
-        if (anns_proto.vector_type() ==
-            milvus::proto::plan::VectorType::BinaryVector) {
-            return std::make_unique<BinaryVectorANNS>();
-        } else if (anns_proto.vector_type() ==
-                   milvus::proto::plan::VectorType::Float16Vector) {
-            return std::make_unique<Float16VectorANNS>();
-        } else if (anns_proto.vector_type() ==
-                   milvus::proto::plan::VectorType::BFloat16Vector) {
-            return std::make_unique<BFloat16VectorANNS>();
-        } else if (anns_proto.vector_type() ==
-                   milvus::proto::plan::VectorType::SparseFloatVector) {
-            return std::make_unique<SparseFloatVectorANNS>();
-        } else if (anns_proto.vector_type() ==
-                   milvus::proto::plan::VectorType::Int8Vector) {
-            return std::make_unique<Int8VectorANNS>();
-        } else if (anns_proto.vector_type() ==
-                   milvus::proto::plan::VectorType::EmbListFloatVector) {
-            return std::make_unique<EmbListFloatVectorANNS>();
-        } else {
-            return std::make_unique<FloatVectorANNS>();
-        }
-    }();
+    auto plan_node = std::make_unique<VectorPlanNode>();
     plan_node->placeholder_tag_ = anns_proto.placeholder_tag();
     plan_node->search_info_ = std::move(search_info_parser());
 


### PR DESCRIPTION
Remove redundant `VectorPlanNode` subclasses and simplify the visitor pattern by consolidating to a single `VectorPlanNode`.

The previous design used distinct `VectorPlanNode` subclasses and a templated `VectorVisitorImpl` for type-directed dispatch. However, the template parameter was not functionally used to implement different logic for each vector type, making the subclasses redundant for their intended purpose.

---
<a href="https://cursor.com/background-agent?bcId=bc-eefd5603-1b9c-490e-8950-e57573d66151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eefd5603-1b9c-490e-8950-e57573d66151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

