### PR TITLE
⚡ [performance] Batch Etcd Deletions in CleanSession

### DIFF
--- a/cmd/milvus/util.go
+++ b/cmd/milvus/util.go
@@ -223,9 +223,14 @@ func CleanSession(metaPath string, etcdEndpoints []string, sessionSuffix []strin
 		return nil
 	}
 
-	for _, key := range keys {
-		_, _ = etcdCli.Delete(ctx, key)
-	}
+	_ = etcd.RemoveByBatchWithLimit(keys, 128, func(partialKeys []string) error {
+		ops := make([]clientv3.Op, 0, len(partialKeys))
+		for _, key := range partialKeys {
+			ops = append(ops, clientv3.OpDelete(key))
+		}
+		_, err := etcdCli.Txn(ctx).Then(ops...).Commit()
+		return err
+	})
 	log.Ctx(ctx).Info("clean sessions from etcd", zap.Any("keys", keys))
 	return nil
 }


### PR DESCRIPTION
Optimized Etcd session cleaning by batching deletions in `cmd/milvus/util.go`. replaced iterative `Delete` calls with a batched transaction using `etcd.RemoveByBatchWithLimit` (limit 128). This significantly reduces network round-trips during session cleanup.

---
*PR created automatically by Jules for task [5416883213365339108](https://jules.google.com/task/5416883213365339108) started by @zhengbuqian*